### PR TITLE
include python environment in generate-wheels nix app

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+.direnv/

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         ./modules/generators.nix
         ./modules/generated-tests.nix
         ./modules/generated-packages.nix
+        ./modules/python-dependencies.nix
         ./modules/apps.nix
         ./modules/devshell.nix
         ./modules/custom-packages.nix

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -103,7 +103,7 @@ in {
     # Individual source generation scripts
     generateSourceScripts =
       mapAttrs' (sourceName: cmdInfo: {
-        name = "generate-${sourceName}";
+        name = sourceName;
         value = pkgs.writeShellScript "generate-${sourceName}-wheels" ''
           set -euo pipefail
 

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -75,7 +75,7 @@ in {
           mkdir -p "$SOURCE_OUTPUT"
 
           cd "$SOURCE_OUTPUT"
-          ${pkgs.python3}/bin/python ${../nix_wheel_generator.py} --config ${wheelGeneratorConfig} --source ${sourceName} --packages ${concatStringsSep "," cmdInfo.wheelNames} --version-limit ${toString cfg.sources.${sourceName}.default_version_limit} --output-dir . "$@"
+          ${config.wheels.python.wheelGeneratorEnv}/bin/python ${../nix_wheel_generator.py} --config ${wheelGeneratorConfig} --source ${sourceName} --packages ${concatStringsSep "," cmdInfo.wheelNames} --version-limit ${toString cfg.sources.${sourceName}.default_version_limit} --output-dir . "$@"
           cd - > /dev/null
 
           echo "   ✅ ${sourceName} wheels generated in $SOURCE_OUTPUT"
@@ -116,7 +116,7 @@ in {
 
           # Run the generation
           cd "$OUTPUT_DIR"
-          ${pkgs.python3}/bin/python ${../nix_wheel_generator.py} --config ${wheelGeneratorConfig} --source ${sourceName} --packages ${concatStringsSep "," cmdInfo.wheelNames} --version-limit ${toString cfg.sources.${sourceName}.default_version_limit} --output-dir . "$@"
+          ${config.wheels.python.wheelGeneratorEnv}/bin/python ${../nix_wheel_generator.py} --config ${wheelGeneratorConfig} --source ${sourceName} --packages ${concatStringsSep "," cmdInfo.wheelNames} --version-limit ${toString cfg.sources.${sourceName}.default_version_limit} --output-dir . "$@"
           cd - > /dev/null
 
           echo "✅ ${sourceName} wheels generated successfully!"
@@ -217,7 +217,7 @@ in {
         wheel-generator = {
           type = "app";
           program = "${pkgs.writeShellScript "wheel-generator-wrapper" ''
-            exec ${pkgs.python3}/bin/python ${../nix_wheel_generator.py} --config ${wheelGeneratorConfig} "$@"
+            exec ${config.wheels.python.wheelGeneratorEnv}/bin/python ${../nix_wheel_generator.py} --config ${wheelGeneratorConfig} "$@"
           ''}";
           meta.description = "Direct access to the wheel generator tool with pre-configured settings";
         };

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -83,6 +83,11 @@ in {
         '')
         cfg.generated.wheelCommands)}
 
+      echo "🎨 Formatting generated Nix files..."
+      find "$OUTPUT_DIR" -name "*.nix" -type f -exec ${pkgs.alejandra}/bin/alejandra {} \;
+      echo "✨ Formatting complete!"
+      echo
+
       echo "🎉 All wheel generation completed!"
       echo "📁 Results available in: $OUTPUT_DIR"
 
@@ -118,6 +123,11 @@ in {
           cd "$OUTPUT_DIR"
           ${config.wheels.python.wheelGeneratorEnv}/bin/python ${../nix_wheel_generator.py} --config ${wheelGeneratorConfig} --source ${sourceName} --packages ${concatStringsSep "," cmdInfo.wheelNames} --version-limit ${toString cfg.sources.${sourceName}.default_version_limit} --output-dir . "$@"
           cd - > /dev/null
+
+          echo "🎨 Formatting generated Nix files..."
+          find "$OUTPUT_DIR" -name "*.nix" -type f -exec ${pkgs.alejandra}/bin/alejandra {} \;
+          echo "✨ Formatting complete!"
+          echo
 
           echo "✅ ${sourceName} wheels generated successfully!"
           echo "📁 Results available in: $OUTPUT_DIR"

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -1,23 +1,12 @@
 # Development shell module for flake-parts
 {...}: {
-  perSystem = {pkgs, ...}: {
+  perSystem = {pkgs, config, ...}: {
     devShells.default = pkgs.mkShell {
       name = "wheels-dev";
 
       buildInputs = with pkgs; [
-        # Python with essential packages for wheel management
-        python3
-        python3Packages.requests
-        python3Packages.packaging
-        python3Packages.pip
-        python3Packages.wheel
-        python3Packages.setuptools
-
-        # Development and testing tools
-        python3Packages.pytest
-        python3Packages.black
-        python3Packages.isort
-        python3Packages.mypy
+        # Python with wheel generation and development packages
+        config.wheels.python.wheelGeneratorEnv
 
         # Nix tools
         nix
@@ -55,11 +44,11 @@
         echo ""
 
         # Make wheel generator available in PATH
-        export PATH="${pkgs.python3}/bin:$PATH"
+        export PATH="${config.wheels.python.wheelGeneratorEnv}/bin:$PATH"
 
         # Set up aliases for convenience
-        alias wg='python ${../nix_wheel_generator.py}'
-        alias wheel-gen='python ${../nix_wheel_generator.py}'
+        alias wg='${config.wheels.python.wheelGeneratorEnv}/bin/python ${../nix_wheel_generator.py}'
+        alias wheel-gen='${config.wheels.python.wheelGeneratorEnv}/bin/python ${../nix_wheel_generator.py}'
         alias test-wheels='nix flake check'
         alias build-wheels='nix build'
 

--- a/modules/generated-packages.nix
+++ b/modules/generated-packages.nix
@@ -85,7 +85,7 @@ in {
     utilityPackages = {
       # Wheel generator with current config
       wheel-generator = pkgs.writeShellScriptBin "wheel-generator" ''
-        exec ${pkgs.python3}/bin/python ${../nix_wheel_generator.py} "$@"
+        exec ${lib.getExe pkgs.python3} ${../nix_wheel_generator.py} "$@"
       '';
 
       # Config inspector - shows current wheel configuration

--- a/modules/python-dependencies.nix
+++ b/modules/python-dependencies.nix
@@ -1,0 +1,70 @@
+# Python Dependencies Module for Zeus Wheels
+# Provides shared Python package dependencies for wheel generation and development
+{
+  config,
+  lib,
+  flake-parts-lib,
+  ...
+}: let
+  inherit (flake-parts-lib) mkPerSystemOption;
+in {
+  options.perSystem = mkPerSystemOption ({
+    config,
+    pkgs,
+    system,
+    ...
+  }: {
+    options.wheels.python = {
+      wheelGeneratorEnv = lib.mkOption {
+        type = lib.types.package;
+        description = "Python environment with wheel generator dependencies";
+      };
+
+      devDependencies = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        description = "List of Python packages needed for development";
+      };
+
+      generatorDependencies = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        description = "List of Python packages needed for wheel generation";
+      };
+    };
+  });
+
+  config.perSystem = {
+    config,
+    pkgs,
+    system,
+    ...
+  }: let
+    # Core Python packages needed for wheel generation
+    generatorDependencies = with pkgs.python3Packages; [
+      requests
+      beautifulsoup4
+      jinja2
+      packaging
+      pip
+      wheel
+      setuptools
+    ];
+
+    # Additional development tools
+    devToolDependencies = with pkgs.python3Packages; [
+      pytest
+      black
+      isort
+      mypy
+    ];
+
+    # Create a Python environment with all generator dependencies
+    wheelGeneratorEnv = pkgs.python3.withPackages (ps: generatorDependencies);
+
+  in {
+    wheels.python = {
+      inherit wheelGeneratorEnv;
+      generatorDependencies = generatorDependencies;
+      devDependencies = generatorDependencies ++ devToolDependencies;
+    };
+  };
+} 


### PR DESCRIPTION
- Create new python-dependencies.nix module to manage shared dependencies
- Update apps to use wheelGeneratorEnv for proper dependencies
- Refactor devshell to use shared Python environment
- Fix generate-wheels app to work outside devshell

This change ensures that the wheel generation tools have all required Python dependencies available whether run inside or outside the devshell.